### PR TITLE
Add support for using custom tick text

### DIFF
--- a/src/main/java/com/visualticks/BaseVisualTicksOverlay.java
+++ b/src/main/java/com/visualticks/BaseVisualTicksOverlay.java
@@ -11,6 +11,7 @@ import net.runelite.client.ui.overlay.OverlayPosition;
 
 import java.awt.*;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.List;
 
 public abstract class BaseVisualTicksOverlay extends Overlay
@@ -51,6 +52,25 @@ public abstract class BaseVisualTicksOverlay extends Overlay
     protected abstract Color getCurrentTickTextColour();
     protected abstract TickShape getTickShape();
     protected abstract int getTickArc();
+    protected abstract boolean shouldShowCustomText();
+    protected abstract String getCustomTickText();
+
+    protected String[] customTickText;
+
+    protected String getTickText(int tickIndex){
+        String tickText = String.valueOf(tickIndex + 1);
+        if (shouldShowCustomText()){
+            if (customTickText.length > tickIndex){
+                tickText = customTickText[tickIndex];
+            }
+        }
+        return tickText;
+    }
+
+    protected void calculateCustomTickText() {
+        configChanged = false;
+        customTickText = Arrays.stream(getCustomTickText().split(",")).map(String::trim).toArray(String[]::new);
+    }
 
     protected void calculateSizes(Graphics2D g) {
         configChanged = false;
@@ -71,7 +91,7 @@ public abstract class BaseVisualTicksOverlay extends Overlay
         {
             int boundingSize = shouldShowTickShape() ? shapeSize : 0;
 
-            String text = String.valueOf(i + 1);
+            String text = getTickText(i);
             int textWidth = fm.stringWidth(text);
             int textHeight = fm.getAscent();
 
@@ -107,6 +127,7 @@ public abstract class BaseVisualTicksOverlay extends Overlay
     public Dimension render(Graphics2D graphics)
     {
         if(configChanged) {
+            calculateCustomTickText();
             calculateSizes(graphics);
         }
 
@@ -135,7 +156,7 @@ public abstract class BaseVisualTicksOverlay extends Overlay
             }
             if (shouldShowText()) {
                 graphics.setColor(i == getCurrentTick() ? getCurrentTickTextColour() : getTickTextColour());
-                graphics.drawString(String.valueOf(i + 1), tick.getFontX(), tick.getFontY());
+                graphics.drawString(getTickText(i), tick.getFontX(), tick.getFontY());
             }
         }
 

--- a/src/main/java/com/visualticks/VisualTicksConfig.java
+++ b/src/main/java/com/visualticks/VisualTicksConfig.java
@@ -200,11 +200,29 @@ public interface VisualTicksConfig extends Config {
     }
 
     @ConfigItem(
+            keyName = "shouldShowCustomTextOne",
+            name = "Show custom text",
+            description = "Show custom text of the current tick",
+            section = tickSettings,
+            position = 14
+    )
+    default boolean shouldShowCustomTextOne() { return false; }
+
+    @ConfigItem(
+            keyName = "customTextOne",
+            name = "Custom text",
+            description = "Custom text to show on each tick, separated by commas",
+            section = tickSettings,
+            position = 15
+    )
+    default String customTextOne() { return "1,2,3"; }
+
+    @ConfigItem(
             keyName = "horizontalSpacingOne",
             name = "Horizontal spacing",
             description = "The amount of space between ticks on the x-axis",
             section = tickSettings,
-            position = 14
+            position = 16
     )
     @Range(min = -50)
     default int horizontalSpacingOne() {
@@ -216,7 +234,7 @@ public interface VisualTicksConfig extends Config {
             name = "Vertical spacing",
             description = "The amount of space between ticks on the y-axis",
             section = tickSettings,
-            position = 15
+            position = 17
     )
     @Range(min = -50)
     default int verticalSpacingOne() {
@@ -395,11 +413,29 @@ public interface VisualTicksConfig extends Config {
     }
 
     @ConfigItem(
+            keyName = "shouldShowCustomTextTwo",
+            name = "Show custom text",
+            description = "Show custom text of the current tick",
+            section = tickSettingsTwo,
+            position = 14
+    )
+    default boolean shouldShowCustomTextTwo() { return false; }
+
+    @ConfigItem(
+            keyName = "customTextTwo",
+            name = "Custom text",
+            description = "Custom text to show on each tick, separated by commas",
+            section = tickSettingsTwo,
+            position = 15
+    )
+    default String customTextTwo() { return "1,2,3"; }
+
+    @ConfigItem(
             keyName = "horizontalSpacingTwo",
             name = "Horizontal spacing",
             description = "The amount of space between ticks on the x-axis",
             section = tickSettingsTwo,
-            position = 14
+            position = 16
     )
     @Range(min = -50)
     default int horizontalSpacingTwo() {
@@ -411,7 +447,7 @@ public interface VisualTicksConfig extends Config {
             name = "Vertical spacing",
             description = "The amount of space between ticks on the y-axis",
             section = tickSettingsTwo,
-            position = 15
+            position = 17
     )
     @Range(min = -50)
     default int verticalSpacingTwo() {
@@ -590,11 +626,29 @@ public interface VisualTicksConfig extends Config {
     }
 
     @ConfigItem(
+            keyName = "shouldShowCustomTextThree",
+            name = "Show custom text",
+            description = "Show custom text of the current tick",
+            section = tickSettingsThree,
+            position = 14
+    )
+    default boolean shouldShowCustomTextThree() { return false; }
+
+    @ConfigItem(
+            keyName = "customTextThree",
+            name = "Custom text",
+            description = "Custom text to show on each tick, separated by commas",
+            section = tickSettingsThree,
+            position = 15
+    )
+    default String customTextThree() { return "1,2,3"; }
+
+    @ConfigItem(
             keyName = "horizontalSpacingThree",
             name = "Horizontal spacing",
             description = "The amount of space between ticks on the x-axis",
             section = tickSettingsThree,
-            position = 14
+            position = 16
     )
     @Range(min = -50)
     default int horizontalSpacingThree() {
@@ -606,7 +660,7 @@ public interface VisualTicksConfig extends Config {
             name = "Vertical spacing",
             description = "The amount of space between ticks on the y-axis",
             section = tickSettingsThree,
-            position = 15
+            position = 17
     )
     @Range(min = -50)
     default int verticalSpacingThree() {

--- a/src/main/java/com/visualticks/VisualTicksOverlayOne.java
+++ b/src/main/java/com/visualticks/VisualTicksOverlayOne.java
@@ -95,4 +95,10 @@ public class VisualTicksOverlayOne extends BaseVisualTicksOverlay
     protected int getTickArc() {
         return config.tickArcOne();
     }
+
+    @Override
+    protected boolean shouldShowCustomText() { return config.shouldShowCustomTextOne(); }
+
+    @Override
+    protected String getCustomTickText() { return config.customTextOne(); }
 }

--- a/src/main/java/com/visualticks/VisualTicksOverlayThree.java
+++ b/src/main/java/com/visualticks/VisualTicksOverlayThree.java
@@ -95,4 +95,10 @@ public class VisualTicksOverlayThree extends BaseVisualTicksOverlay
     protected int getTickArc() {
         return config.tickArcThree();
     }
+
+    @Override
+    protected boolean shouldShowCustomText() { return config.shouldShowCustomTextThree(); }
+
+    @Override
+    protected String getCustomTickText() { return config.customTextThree(); }
 }

--- a/src/main/java/com/visualticks/VisualTicksOverlayTwo.java
+++ b/src/main/java/com/visualticks/VisualTicksOverlayTwo.java
@@ -95,4 +95,10 @@ public class VisualTicksOverlayTwo extends BaseVisualTicksOverlay
     protected int getTickArc() {
         return config.tickArcTwo();
     }
+
+    @Override
+    protected boolean shouldShowCustomText() { return config.shouldShowCustomTextTwo(); }
+
+    @Override
+    protected String getCustomTickText() { return config.customTextTwo(); }
 }


### PR DESCRIPTION
Add support for adding custom tick text

Addresses suggestion #5.


## Screenshots

### In-game

<img width="253" height="159" alt="image" src="https://github.com/user-attachments/assets/aa4fca76-aa30-4b2c-9993-68132f7f3f16" />

### Configuration

`1,2,3,🔥,5, six,7,8,9,ten,🕺,🐟`

<img width="232" height="563" alt="image" src="https://github.com/user-attachments/assets/855ac9a9-97b5-4d7c-9d2b-cae8a012da3d" />
